### PR TITLE
fix: Remove trial rollback on generation failure to prevent infinite …

### DIFF
--- a/api/app/worker/tasks.py
+++ b/api/app/worker/tasks.py
@@ -302,15 +302,6 @@ def _refund_generation_cost(session, request) -> None:
     )
 
 
-def _rollback_trial_use(session, request_id: int) -> None:
-    """Rollback trial usage for failed generation."""
-    from app.db.models import TrialUse
-
-    trial = session.query(TrialUse).filter(TrialUse.request_id == request_id).first()
-    if trial:
-        session.delete(trial)
-
-
 def _mark_generation_failed(request_id: int, error_message: str) -> None:
     """Mark generation as failed in DB."""
     from app.db.models import (
@@ -328,7 +319,6 @@ def _mark_generation_failed(request_id: int, error_message: str) -> None:
                 request.status = GenerationStatus.failed
                 request.completed_at = datetime.utcnow()
                 _refund_generation_cost(session, request)
-                _rollback_trial_use(session, request.id)
 
             job = session.query(GenerationJob).filter(GenerationJob.request_id == request_id).first()
             if job:

--- a/api/tests/unit/test_tasks.py
+++ b/api/tests/unit/test_tasks.py
@@ -15,7 +15,6 @@ from app.worker.tasks import (
     _normalize_outputs,
     _refund_generation_cost,
     _resolve_language,
-    _rollback_trial_use,
 )
 
 


### PR DESCRIPTION
…free generations

Root cause: When a generation failed (during Wavespeed polling or immediately), `_rollback_trial_use` deleted the TrialUse record from the database. This meant `trial_available()` returned True again on the next attempt, allowing the user to generate for free indefinitely in a loop:

  submit → trial used → Wavespeed queued → fail during polling →
  trial rolled back → submit again → trial available → free again → ...

Fix: Remove all `rollback_trial_use` / `_rollback_trial_use` calls. Once a trial is consumed, it stays consumed regardless of generation outcome. Failed generations still get credit refunds via `_refund_generation_cost`, but the trial slot is not restored.

Removed from:
- api/app/worker/tasks.py: _mark_generation_failed no longer rolls back trial
- api/app/api/v1/endpoints/generations.py: Wavespeed submission error handlers and refresh_generation status check
- Deleted both rollback_trial_use function definitions (unused)

https://claude.ai/code/session_01ML6RMqYxYoUeBmQCsWLpoU