### PR TITLE
feat(admin-panel): make admin panel fully responsive for mobile devices

### DIFF
--- a/admin-panel/src/components/DataTable.tsx
+++ b/admin-panel/src/components/DataTable.tsx
@@ -160,8 +160,9 @@ export function DataTable<T>({
 
       {/* Pagination */}
       {pagination && pagination.total > 0 && (
-        <div className="flex items-center justify-between px-4 py-3 border-t border-surface-lighter/50">
-          <p className="text-xs text-muted-foreground">
+        <div className="flex items-center gap-2 px-4 py-3 border-t border-surface-lighter/50">
+          {/* Showing X-Y of Z — hidden on very small screens */}
+          <p className="text-xs text-muted-foreground hidden sm:block mr-auto">
             Showing{' '}
             <span className="text-white font-medium">{pagination.offset + 1}</span>
             {' - '}
@@ -171,7 +172,7 @@ export function DataTable<T>({
             {' of '}
             <span className="text-white font-medium">{pagination.total.toLocaleString()}</span>
           </p>
-          <div className="flex items-center gap-1">
+          <div className="flex items-center gap-1 ml-auto sm:ml-0">
             <button
               onClick={() => handleGoToPage(1)}
               disabled={currentPage === 1}
@@ -188,8 +189,9 @@ export function DataTable<T>({
             >
               <ChevronLeft className="w-4 h-4" />
             </button>
-            <span className="px-3 text-xs text-muted-foreground">
-              Page <span className="text-white font-medium">{currentPage}</span> of{' '}
+            <span className="px-2 text-xs text-muted-foreground whitespace-nowrap">
+              <span className="text-white font-medium">{currentPage}</span>
+              {' / '}
               <span className="text-white font-medium">{totalPages}</span>
             </span>
             <button

--- a/admin-panel/src/components/layout/AppLayout.tsx
+++ b/admin-panel/src/components/layout/AppLayout.tsx
@@ -1,20 +1,31 @@
+import { useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import { Sidebar } from './Sidebar';
 import { Topbar } from './Topbar';
 
 export function AppLayout() {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
   return (
     <div className="min-h-screen bg-dark-500 flex">
+      {/* Mobile overlay backdrop */}
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 bg-black/60 z-20 lg:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+
       {/* Sidebar */}
-      <Sidebar />
+      <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
       {/* Main content area */}
-      <div className="flex-1 ml-sidebar flex flex-col min-h-screen">
+      <div className="flex-1 lg:ml-sidebar flex flex-col min-h-screen min-w-0">
         {/* Topbar */}
-        <Topbar />
+        <Topbar onMenuClick={() => setSidebarOpen((prev) => !prev)} />
 
         {/* Page content */}
-        <main className="flex-1 p-6 pt-4 overflow-y-auto scrollbar-thin">
+        <main className="flex-1 p-4 lg:p-6 lg:pt-4 overflow-y-auto scrollbar-thin">
           <div className="max-w-7xl mx-auto animate-fade-in">
             <Outlet />
           </div>

--- a/admin-panel/src/components/layout/Sidebar.tsx
+++ b/admin-panel/src/components/layout/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import {
   LayoutDashboard,
@@ -18,6 +19,11 @@ interface NavItem {
   icon: LucideIcon;
 }
 
+interface SidebarProps {
+  open?: boolean;
+  onClose?: () => void;
+}
+
 const navItems: NavItem[] = [
   { label: 'Dashboard', path: '/', icon: LayoutDashboard },
   { label: 'Users', path: '/users', icon: Users },
@@ -29,8 +35,13 @@ const navItems: NavItem[] = [
   { label: 'Settings', path: '/settings', icon: Settings },
 ];
 
-export function Sidebar() {
+export function Sidebar({ open = false, onClose }: SidebarProps) {
   const location = useLocation();
+
+  // Close sidebar on navigation (mobile)
+  useEffect(() => {
+    onClose?.();
+  }, [location.pathname]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function isActive(path: string): boolean {
     if (path === '/') return location.pathname === '/';
@@ -38,7 +49,15 @@ export function Sidebar() {
   }
 
   return (
-    <aside className="fixed left-0 top-0 bottom-0 w-sidebar bg-sidebar border-r border-sidebar-border flex flex-col z-30">
+    <aside
+      className={cn(
+        'fixed left-0 top-0 bottom-0 w-sidebar bg-sidebar border-r border-sidebar-border flex flex-col z-30',
+        'transition-transform duration-300 ease-in-out',
+        // Desktop: always visible; Mobile: slide in/out
+        'lg:translate-x-0',
+        open ? 'translate-x-0' : '-translate-x-full',
+      )}
+    >
       {/* Logo */}
       <div className="h-topbar flex items-center px-6 border-b border-sidebar-border">
         <div className="flex items-center gap-2.5">

--- a/admin-panel/src/components/layout/Topbar.tsx
+++ b/admin-panel/src/components/layout/Topbar.tsx
@@ -1,5 +1,5 @@
 import { useLocation, useNavigate } from 'react-router-dom';
-import { LogOut, User } from 'lucide-react';
+import { LogOut, Menu, User } from 'lucide-react';
 import { useAuthStore } from '@/stores/authStore';
 import { clearToken } from '@/api/client';
 
@@ -28,7 +28,11 @@ function getPageTitle(pathname: string): string {
   return 'Dashboard';
 }
 
-export function Topbar() {
+interface TopbarProps {
+  onMenuClick?: () => void;
+}
+
+export function Topbar({ onMenuClick }: TopbarProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const { admin, logout } = useAuthStore();
@@ -42,9 +46,17 @@ export function Topbar() {
   };
 
   return (
-    <header className="h-topbar bg-dark-500/80 backdrop-blur-md border-b border-surface-lighter/30 flex items-center justify-between px-6 sticky top-0 z-20">
-      {/* Page title */}
-      <div>
+    <header className="h-topbar bg-dark-500/80 backdrop-blur-md border-b border-surface-lighter/30 flex items-center justify-between px-4 lg:px-6 sticky top-0 z-20">
+      {/* Left: hamburger (mobile) + page title */}
+      <div className="flex items-center gap-3">
+        {/* Hamburger button — mobile only */}
+        <button
+          onClick={onMenuClick}
+          className="lg:hidden p-2 rounded-lg text-muted-foreground hover:text-white hover:bg-surface-light transition-colors"
+          aria-label="Toggle menu"
+        >
+          <Menu className="w-5 h-5" />
+        </button>
         <h1 className="text-lg font-semibold text-white">{title}</h1>
       </div>
 

--- a/admin-panel/src/pages/DashboardPage.tsx
+++ b/admin-panel/src/pages/DashboardPage.tsx
@@ -122,7 +122,7 @@ export function DashboardPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
           <h2 className="text-2xl font-bold text-white">Dashboard</h2>
           <p className="text-sm text-muted-foreground mt-1">

--- a/admin-panel/src/pages/broadcasts/BroadcastsListPage.tsx
+++ b/admin-panel/src/pages/broadcasts/BroadcastsListPage.tsx
@@ -195,7 +195,7 @@ export function BroadcastsListPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
           <h2 className="text-2xl font-bold text-white">Broadcasts</h2>
           <p className="text-sm text-muted-foreground mt-1">
@@ -204,7 +204,7 @@ export function BroadcastsListPage() {
         </div>
         <button
           onClick={() => navigate('/broadcasts/new')}
-          className="btn-primary flex items-center gap-2"
+          className="btn-primary flex items-center gap-2 self-start sm:self-auto"
         >
           <Plus className="w-4 h-4" />
           New Broadcast

--- a/admin-panel/src/pages/generations/GenerationsPage.tsx
+++ b/admin-panel/src/pages/generations/GenerationsPage.tsx
@@ -300,11 +300,11 @@ function Pagination({
   if (totalPages <= 1) return null;
 
   return (
-    <div className="flex items-center justify-between px-4 py-3">
-      <p className="text-sm text-muted-foreground">
+    <div className="flex items-center gap-2 px-4 py-3">
+      <p className="text-sm text-muted-foreground hidden sm:block mr-auto">
         Page {page + 1} of {totalPages}
       </p>
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-1 ml-auto sm:ml-0">
         <button
           onClick={() => onPageChange(page - 1)}
           disabled={page === 0}

--- a/admin-panel/src/pages/models/ModelsPage.tsx
+++ b/admin-panel/src/pages/models/ModelsPage.tsx
@@ -260,7 +260,7 @@ export function ModelsPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
         <div>
           <h2 className="text-2xl font-bold text-white">Models</h2>
           <p className="text-sm text-muted-foreground mt-1">

--- a/admin-panel/src/pages/payments/PaymentsPage.tsx
+++ b/admin-panel/src/pages/payments/PaymentsPage.tsx
@@ -38,11 +38,11 @@ function Pagination({
   if (totalPages <= 1) return null;
 
   return (
-    <div className="flex items-center justify-between px-4 py-3">
-      <p className="text-sm text-muted-foreground">
+    <div className="flex items-center gap-2 px-4 py-3">
+      <p className="text-sm text-muted-foreground hidden sm:block mr-auto">
         Page {page + 1} of {totalPages}
       </p>
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-1 ml-auto sm:ml-0">
         <button
           onClick={() => onPageChange(page - 1)}
           disabled={page === 0}
@@ -293,7 +293,7 @@ export function PaymentsPage() {
 
       {/* Revenue Chart */}
       <div>
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
           <h3 className="text-sm font-semibold text-white">Payment Revenue</h3>
           <div className="flex items-center gap-1">
             {DATE_PRESETS.map((preset) => (

--- a/admin-panel/src/pages/settings/SettingsPage.tsx
+++ b/admin-panel/src/pages/settings/SettingsPage.tsx
@@ -410,7 +410,7 @@ export function SettingsPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
           <h2 className="text-2xl font-bold text-white">Settings</h2>
           <p className="text-sm text-muted-foreground mt-1">
@@ -421,7 +421,7 @@ export function SettingsPage() {
           onClick={handleSave}
           disabled={!isDirty || saveMutation.isPending}
           className={cn(
-            'btn-primary flex items-center gap-2',
+            'btn-primary flex items-center gap-2 self-start sm:self-auto',
             (!isDirty || saveMutation.isPending) && 'opacity-50 cursor-not-allowed',
           )}
         >
@@ -460,13 +460,13 @@ export function SettingsPage() {
 
       {/* Unsaved Changes Bar */}
       {isDirty && (
-        <div className="sticky bottom-6 z-40">
-          <div className="flex items-center justify-between bg-dark-300 border border-banana-500/30 rounded-lg px-5 py-3 shadow-glow">
+        <div className="sticky bottom-4 lg:bottom-6 z-40">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 bg-dark-300 border border-banana-500/30 rounded-lg px-5 py-3 shadow-glow">
             <div className="flex items-center gap-2">
-              <Settings className="w-4 h-4 text-banana-500" />
+              <Settings className="w-4 h-4 text-banana-500 flex-shrink-0" />
               <p className="text-sm text-white font-medium">You have unsaved changes</p>
             </div>
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3 self-end sm:self-auto">
               <button
                 onClick={() => {
                   if (settingsQuery.data) {

--- a/admin-panel/src/pages/users/UserDetailPage.tsx
+++ b/admin-panel/src/pages/users/UserDetailPage.tsx
@@ -292,7 +292,7 @@ export function UserDetailPage() {
       ) : user ? (
         <div className="card-admin p-6">
           {/* User header */}
-          <div className="flex items-start justify-between mb-6">
+          <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
             <div className="flex items-center gap-4">
               {/* Avatar */}
               {user.photo_url ? (
@@ -350,7 +350,7 @@ export function UserDetailPage() {
             <button
               onClick={() => setShowBanConfirm(true)}
               className={cn(
-                'flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors',
+                'flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors self-start',
                 user.is_banned
                   ? 'bg-success-muted text-success hover:bg-success/20'
                   : 'bg-destructive-muted text-destructive hover:bg-destructive/20',
@@ -434,7 +434,7 @@ export function UserDetailPage() {
             </div>
             <div className="md:col-span-2">
               <label className="block text-xs text-muted-foreground mb-1.5">Reason</label>
-              <div className="flex gap-3">
+              <div className="flex flex-col sm:flex-row gap-3">
                 <textarea
                   value={creditReason}
                   onChange={(e) => setCreditReason(e.target.value)}
@@ -445,7 +445,7 @@ export function UserDetailPage() {
                 <button
                   onClick={() => creditMutation.mutate()}
                   disabled={!isCreditFormValid || creditMutation.isPending}
-                  className="btn-primary whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="btn-primary whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed w-full sm:w-auto"
                 >
                   {creditMutation.isPending ? 'Adjusting...' : 'Adjust Credits'}
                 </button>

--- a/admin-panel/src/pages/users/UsersListPage.tsx
+++ b/admin-panel/src/pages/users/UsersListPage.tsx
@@ -220,7 +220,7 @@ export function UsersListPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
         <div>
           <h2 className="text-2xl font-bold text-white">Users</h2>
           <p className="text-sm text-muted-foreground mt-1">

--- a/admin-panel/src/pages/wavespeed/WavespeedPage.tsx
+++ b/admin-panel/src/pages/wavespeed/WavespeedPage.tsx
@@ -86,14 +86,14 @@ export function WavespeedPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
           <h2 className="text-2xl font-bold text-white">Wavespeed Provider</h2>
           <p className="text-sm text-muted-foreground mt-1">
             Monitor Wavespeed API status, balance, and generation analytics.
           </p>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 self-start sm:self-auto">
           {data && <StatusBadge status={data.provider_status} />}
           <button
             onClick={() => refetch()}


### PR DESCRIPTION
- Layout: sidebar becomes a slide-in drawer on mobile (lg breakpoint),
  with overlay backdrop and auto-close on navigation
- Topbar: add hamburger menu button (lg:hidden) to toggle sidebar on mobile;
  reduce horizontal padding on small screens
- AppLayout: add sidebarOpen state, mobile overlay backdrop, responsive
  main content margin (lg:ml-sidebar), and reduced padding (p-4 lg:p-6)
- DataTable: compact pagination on mobile — hide "Showing X-Y of Z" on
  small screens, keep nav buttons always visible
- Page headers: fix flex layouts across all pages to stack vertically on
  mobile (flex-col sm:flex-row sm:justify-between) — Dashboard, Settings,
  Users, Models, Broadcasts, Wavespeed
- SettingsPage: unsaved changes bar also stacks on mobile
- UserDetailPage: user header stacks on mobile; credit adjustment textarea
  + button wrap to column on mobile
- Payments/Generations: local Pagination components also made responsive

https://claude.ai/code/session_01T1uzGAAsPNNPZUDaYEMQjk